### PR TITLE
[Bug] 게시글 수정 시 컨텐츠 파싱 오류 해결

### DIFF
--- a/src/app/(protected)/edit/[id]/_components/EditPostClient.tsx
+++ b/src/app/(protected)/edit/[id]/_components/EditPostClient.tsx
@@ -13,14 +13,14 @@ interface EditPostClientProps {
   post: {
     id: string;
     title: string;
-    content: string;
+    content: JSONContent;
     tags: string[];
   };
 }
 
 export default function EditPostClient({ post }: EditPostClientProps) {
   const [title, setTitle] = useState(post.title);
-  const [content, setContent] = useState<JSONContent | null>(JSON.parse(post.content));
+  const [content, setContent] = useState<JSONContent>(post.content);
   const [tags, setTags] = useState<string[]>(post.tags || []);
   const [tagInput, setTagInput] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/src/components/editor/TiptapViewer.tsx
+++ b/src/components/editor/TiptapViewer.tsx
@@ -5,30 +5,16 @@ import Image from '@tiptap/extension-image';
 import { useEditor, EditorContent, JSONContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { common, createLowlight } from 'lowlight';
-import { useMemo } from 'react';
 
 const lowlight = createLowlight(common);
 
 interface TiptapViewerProps {
-  content: JSONContent | string | any;
+  content: JSONContent;
 }
 
 export default function TiptapViewer({ content }: TiptapViewerProps) {
-  const parsedContent = useMemo(() => {
-    if (!content) return '';
-
-    if (typeof content === 'string') {
-      try {
-        return JSON.parse(content);
-      } catch (e) {
-        return content;
-      }
-    }
-    return content;
-  }, [content]);
-
   const editor = useEditor({
-    content: parsedContent,
+    content,
     editable: false, // Read Only
     immediatelyRender: false,
     extensions: [


### PR DESCRIPTION
### 연관 이슈

Closes #9 

### 원인

Supabase의 기반이 되는 PostgreSQL DB는 JSON이나 JSONB과 같은 데이터 타입으로 구조화된 데이터를 인식하고 저장함

현제 프로젝트에서 사용한 `@supabase/supabase-js` 클라이언트는 DB에서 데이터를 꺼내올 때 해당 컬럼의 데이터 타입을 확인함

그 후 데이터 타입에 맞게 내부적으로 자동으로 파싱하고 그 결과를 넘겨 줌. 이는 자동 변환(Auto-Parsing)임

그래서 데이터를 클라이언트에서 서버로 전송할 때는 `JSON.stringify`를 필요로 하지만 DB에서 `select()`로 꺼내온 데이터는 파싱을 필요로 하지 않음

### 해결

게시글의 컨텐츠 데이터를 꺼내온 뒤 수행하던 파싱을 모두 제거하며 해결.

> [Supabase | Auto Generated REST API](https://supabase.com/features/auto-generated-rest-api)