### PR TITLE
[Feat] tiptap에디터 및 게시글 관련 개선 사항 반영

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -66,3 +66,47 @@ body {
 .flip-card-back {
   transform: rotateY(180deg);
 }
+
+/* Tiptap Blockquote Styling */
+.prose blockquote {
+  border-left: 4px solid #f97316;
+  background-color: #fffaf0;
+  padding: 0 1rem;
+  font-style: italic;
+  color: #4b5563;
+  quotes: none;
+}
+
+.prose blockquote p:first-of-type::before,
+.prose blockquote p:last-of-type::after {
+  content: none !important;
+}
+
+@media (prefers-color-scheme: dark) {
+  .prose blockquote {
+    background-color: #1a1a1a;
+    color: #d1d5db;
+    border-left-color: #fb923c;
+  }
+}
+
+/* Tiptap Inline Code Styling */
+.prose :not(pre) > code {
+  background-color: #f3f4f6;
+  color: #ea580c;
+  padding: 0.2rem 0.4rem !important;
+  border-radius: 0.375rem;
+  font-weight: 500;
+}
+
+.prose :not(pre) > code::before,
+.prose :not(pre) > code::after {
+  content: none !important;
+}
+
+@media (prefers-color-scheme: dark) {
+  .prose :not(pre) > code {
+    background-color: #262626;
+    color: #fdba74;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,11 +42,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body className={`${geistSans.variable} ${geistMono.variable} ${nanumPen.variable} font-sans text-slate-900 relative antialiased min-h-screen bg-[radial-gradient(#cbd5e1_1px,transparent_1px)] [background-size:24px_24px] dark:bg-[radial-gradient(#334155_1px,transparent_1px)] bg-slate-50 dark:bg-slate-900 dark:text-slate-100`}>
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} ${nanumPen.variable} relative min-h-screen bg-slate-50 bg-[radial-gradient(#cbd5e1_1px,transparent_1px)] bg-size-[24px_24px] font-sans text-slate-900 antialiased dark:bg-slate-900 dark:bg-[radial-gradient(#334155_1px,transparent_1px)] dark:text-slate-100`}
+      >
         <CursorParticles />
         <TanstackQueryLayout>
-            {children}
-            <WriteLinkButton />
+          {children}
+          <WriteLinkButton />
         </TanstackQueryLayout>
         <Analytics />
         <SpeedInsights />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ export default async function HomePage() {
     .from('posts')
     .select('*')
     .order('created_at', { ascending: false })
-    .limit(3);
+    .limit(4);
 
   if (error) {
     console.error('게시글을 불러오는 중 에러 발생:', error);
@@ -45,11 +45,11 @@ export default async function HomePage() {
               </h2>
               <Link
                 href="/posts"
-                className="group relative inline-flex items-center px-2 py-1 font-marker text-2xl font-bold tracking-wide text-brand transition-colors"
+                className="group font-marker text-brand relative inline-flex items-center px-2 py-1 text-2xl font-bold tracking-wide transition-colors"
                 title="View All Posts"
               >
                 <span className="relative z-10">VIEW ALL POSTS</span>
-                <span className="absolute bottom-0 left-0 h-[3px] w-full origin-left scale-x-0 bg-brand transition-transform duration-300 ease-out group-hover:scale-x-100"></span>
+                <span className="bg-brand absolute bottom-0 left-0 h-[3px] w-full origin-left scale-x-0 transition-transform duration-300 ease-out group-hover:scale-x-100"></span>
               </Link>
             </div>
 

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -17,7 +17,7 @@ const getPost = cache(async (id: string) => {
 
 export async function generateMetadata(
   { params }: { params: Promise<{ id: string }> },
-  parent: ResolvingMetadata
+  parent: ResolvingMetadata,
 ): Promise<Metadata> {
   const { id } = await params;
   const { data: post } = await getPost(id);
@@ -89,7 +89,7 @@ export default async function PostDetailPage({ params }: { params: Promise<{ id:
           )}
         </div>
 
-        <div className="relative mb-20 -rotate-1 transform rounded-sm border border-slate-200 bg-white p-10 shadow-xl md:p-14 dark:border-slate-800 dark:bg-slate-900">
+        <div className="relative mb-20 transform rounded-sm border border-slate-200 bg-white p-10 shadow-xl md:p-14 dark:border-slate-800 dark:bg-slate-900">
           {/* Document Pin */}
           <div className="absolute -top-3 left-1/2 z-10 -ml-3 h-6 w-6 rounded-full border-2 border-white/50 bg-red-500 shadow-md"></div>
 

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -90,9 +90,6 @@ export default async function PostDetailPage({ params }: { params: Promise<{ id:
         </div>
 
         <div className="relative mb-20 transform rounded-sm border border-slate-200 bg-white p-10 shadow-xl md:p-14 dark:border-slate-800 dark:bg-slate-900">
-          {/* Document Pin */}
-          <div className="absolute -top-3 left-1/2 z-10 -ml-3 h-6 w-6 rounded-full border-2 border-white/50 bg-red-500 shadow-md"></div>
-
           <header className="mb-10">
             <div className="mb-6 flex flex-wrap gap-2">
               {tags.map((tag: string) => (

--- a/src/components/editor/Toolbar.tsx
+++ b/src/components/editor/Toolbar.tsx
@@ -13,6 +13,7 @@ import {
   Quote,
   ImageIcon,
   PenTool,
+  Heading3,
 } from 'lucide-react';
 
 import { uploadImage } from '@/actions/image';
@@ -85,6 +86,14 @@ export default function Toolbar({ editor }: ToolbarProps) {
         title="Heading 2"
       >
         <Heading2 className="h-5 w-5" />
+      </button>
+      <button
+        type="button"
+        onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+        className={getButtonClass(editor.isActive('heading', { level: 3 }))}
+        title="Heading 3"
+      >
+        <Heading3 className="h-5 w-5" />
       </button>
       <div className="mx-1 h-6 w-px bg-gray-200" /> {/* 구분선 */}
       <button


### PR DESCRIPTION
### 1. 홈페이지 최근 게시물 표시 개수 변경

원래는 홈페이지에서 보여주는 최근 게시물을 3개 보여줬는데, 변경된 홈페이지 디자인에 맞게 4개를 보여주도록 변경

### 2. 게시물 상세 페이지 디자인 개선

원래 게시물 상세 페이지에는 PostCard와 같이 Pin모양 UI가 있었는데 이걸 제거함

추가적으로 게시글의 rotate 스타일을 제거함

### 3. 인용구 스타일 개선

원래는 tiptap의 기본 스타일과 같게 인용구 앞뒤 양 끝에 따옴표가 있었음 (`"`, `"`). 이걸 제거함

추가적으로 배경에 옅은 색상을 넣어서 영역 구분 개선을 도모함

### 4. 인라인 코드 스타일 개선

인라인 코드도 tiptap의 기본 스타일이 적용되어 있어 문자열 양 끝에 백틱 (`) 이 있었음. 이거 제거함

추가적으로 배경을 하이라이팅 해서 인라인 코드를 다른 문자들과 구분함

인라인 코드는 코드블럭과 같은 태그를 사용해서 스타일 선택자를 넣을 때 코드블럭과 확실히 구분해야함

```css
/* 코드블럭인 pre 태그 내부에 존재 */
.prese :not(pre) > code {
  /* 인라인 코드 스타일 작성 */
}
```

### 5. 툴바에 Heading 3 추가

Heading 2와 Heading 3을 많이 사용하는데 툴바에는 2까지 밖에 없어서 3을 추가함